### PR TITLE
Updated sieve-reference for HTML5 compatibility

### DIFF
--- a/en/action/core/discard.html
+++ b/en/action/core/discard.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Core:Discard Action</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css" />
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
   </head>
   <body>
     <h1>Discard</h1>
@@ -33,8 +32,8 @@
     </p>
     <div>
       <code>
-        if header :contains ["from"] ["idiot@example.edu"] {<br/>
-           discard;<br/>
+        if header :contains ["from"] ["idiot@example.edu"] {<br>
+           discard;<br>
         }
       </code>
     </div>

--- a/en/action/core/fileinto.html
+++ b/en/action/core/fileinto.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Core:Fileinto Action</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css" />
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
   </head>
   <body>
     <h1>fileinto</h1>

--- a/en/action/core/keep.html
+++ b/en/action/core/keep.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Core:Keep Action</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css" />
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
   </head>
   <body>
     <h1>Keep</h1>

--- a/en/action/core/redirect.html
+++ b/en/action/core/redirect.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Core:Redirect Action</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css" />
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
   </head>
   <body>
     <h1>Redirect</h1>

--- a/en/action/core/reject.html
+++ b/en/action/core/reject.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Core:Reject Action</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css" />
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
   </head>
   <body>
     <h1>Reject</h1>
@@ -29,9 +28,9 @@
     </p>
     <div>
       <code>
-        if header :contains "from" "coyote@desert.example.org" {<br/>
-                reject "I am not taking mail from you, and I don't want<br/>
-                your birdseed, either!";<br/>
+        if header :contains "from" "coyote@desert.example.org" {<br>
+                reject "I am not taking mail from you, and I don't want<br>
+                your birdseed, either!";<br>
              }
       </code>
     </div>

--- a/en/atoms/core/comments.html
+++ b/en/atoms/core/comments.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Core:Comments</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css" />
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
   </head>
   <body>
     <h1>Comments</h1>
@@ -36,9 +35,9 @@
     <h2>Example</h2>
     <div>
       <code>
-        if size :over 100K { # this is a comment<br />
-        &nbsp;&nbsp;&nbsp;discard;<br />
-        }<br />   
+        if size :over 100K { # this is a comment<br>
+        &nbsp;&nbsp;&nbsp;discard;<br>
+        }<br>   
       </code>
     </div>
     <p>
@@ -46,10 +45,10 @@
     </p>
     <div>
       <code>    
-        if size :over 100K { /* this is a comment<br />
-        &nbsp;&nbsp;&nbsp;this is still a comment */ discard /* this is a comment<br />
-        &nbsp;&nbsp;&nbsp;*/ ;<br />
-        }<br />
+        if size :over 100K { /* this is a comment<br>
+        &nbsp;&nbsp;&nbsp;this is still a comment */ discard /* this is a comment<br>
+        &nbsp;&nbsp;&nbsp;*/ ;<br>
+        }<br>
       </code>
     </div>
         

--- a/en/atoms/core/number.html
+++ b/en/atoms/core/number.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Core:Numbers</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-     <link href="./../../../style/style.css" rel="Stylesheet" type="text/css" />
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+     <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
   </head>
   <body>
     <h1>Numbers</h1>
@@ -37,9 +36,9 @@
     <h2>Example</h2>
     <div>
       <code>
-        if size :over 100K {<br />
-        &nbsp;&nbsp;&nbsp;discard;<br />
-        }<br />   
+        if size :over 100K {<br>
+        &nbsp;&nbsp;&nbsp;discard;<br>
+        }<br>   
       </code>
     </div>
         

--- a/en/atoms/core/string.html
+++ b/en/atoms/core/string.html
@@ -1,22 +1,21 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Core:Strings</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css" />
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
   </head>
   <body>
     <h1>Strings</h1>
     
     <h2>Syntax</h2>  
     <p>
-      <tt>"</tt> <em>*(CHAR)</em> <tt>"</tt>
+      <kbd>"</kbd> <em>*(CHAR)</em> <kbd>"</kbd>
     </p>
     <p>
-      <tt>text:</tt> <em>*( '<tt>&nbsp;</tt>' / TAB) (<a href="./comments.html">hash-comment</a>)<br/>
-      *([CHAR-NOT-DOT *CHAR] CRLF / <tt>.</tt> 1*CHAR CRLF)</em><br/>
-      <tt>.</tt><br/>
+      <kbd>text:</kbd> <em>*( '<kbd>&nbsp;</kbd>' / TAB) (<a href="./comments.html">hash-comment</a>)<br>
+      *([CHAR-NOT-DOT *CHAR] CRLF / <kbd>.</kbd> 1*CHAR CRLF)</em><br/>
+      <kbd>.</kbd><br>
     </p>
 
     <h2>Description</h2>

--- a/en/atoms/core/stringlist.html
+++ b/en/atoms/core/stringlist.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Core:String Lists</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css" />
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
   </head>
   <body>
     <h1>String Lists</h1>

--- a/en/atoms/core/testlist.html
+++ b/en/atoms/core/testlist.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Core:Test Lists</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css" />
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
   </head>
   <body>
     <h1>Test Lists</h1>
@@ -28,10 +27,10 @@
     <h2>Example</h2>
     <div>
       <code>
-        if anyof (not exists ["From", "Date"],<br />
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;header :contains "from" "fool@example.edu") {<br />
-        &nbsp;&nbsp;&nbsp;discard;<br />
-        }<br />
+        if anyof (not exists ["From", "Date"],<br>
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;header :contains "from" "fool@example.edu") {<br>
+        &nbsp;&nbsp;&nbsp;discard;<br>
+        }<br>
       </code>
     </div>
         

--- a/en/content.html
+++ b/en/content.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Sieve Language Reference</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <link href="./../style/style.css" rel="Stylesheet" type="text/css" />
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../style/style.css" rel="Stylesheet" type="text/css">
   </head>
   <body>
     <h1>Index</h1>

--- a/en/control/core/if.html
+++ b/en/control/core/if.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Core:If Control Structure</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css" />
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
   </head>
   <body>
     <h1>If</h1>
@@ -53,14 +52,14 @@
     <h2>Example</h2>
     <div>
       <code>
-        require "fileinto";<br/>
-        if header :contains "from" "coyote" {<br/>
-        &nbsp;&nbsp;&nbsp;redirect "acm@example.edu";<br/>
-        } elsif header :contains ["subject"] ["$$$"] {<br/>
-        &nbsp;&nbsp;&nbsp;discard;<br/>
-        } else {<br/>
-        &nbsp;&nbsp;&nbsp;fileinto "INBOX";<br/>
-        }<br/>
+        require "fileinto";<br>
+        if header :contains "from" "coyote" {<br>
+        &nbsp;&nbsp;&nbsp;redirect "acm@example.edu";<br>
+        } elsif header :contains ["subject"] ["$$$"] {<br>
+        &nbsp;&nbsp;&nbsp;discard;<br>
+        } else {<br>
+        &nbsp;&nbsp;&nbsp;fileinto "INBOX";<br>
+        }<br>
       </code>
     </div>
             

--- a/en/control/core/require.html
+++ b/en/control/core/require.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Core:Require Control Structure</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css" />
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
   </head>
   <body>
     <h1>Require</h1>

--- a/en/control/core/stop.html
+++ b/en/control/core/stop.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Core:Stop Control Structure</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css" />
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
   </head>
   <body>
     <h1>Stop</h1>
@@ -23,17 +22,17 @@
     <h2>Example</h2>
     <div>
       <code>
-        require "reject";<br/>
-        <br/>
-        # Reject any large messages<br/>
-        if size :over 1M<br/>
-        {<br/>
-        &nbsp;&nbsp;reject text: "Do not send me large attachments";<br/>
-        &nbsp;&nbsp;# Stops the Script execution immediately <br/>
-        &nbsp;&nbsp;stop;<br/>
-        }<br/>
-        <br/>
-        # Do more processing...<br/>
+        require "reject";<br>
+        <br>
+        # Reject any large messages<br>
+        if size :over 1M<br>
+        {<br>
+        &nbsp;&nbsp;reject text: "Do not send me large attachments";<br>
+        &nbsp;&nbsp;# Stops the Script execution immediately <br>
+        &nbsp;&nbsp;stop;<br>
+        }<br>
+        <br>
+        # Do more processing...<br>
       </code>
     </div>    
         

--- a/en/index.html
+++ b/en/index.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Sieve Language Reference</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <link href="./../style/style.css" rel="Stylesheet" type="text/css" />
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../style/style.css" rel="Stylesheet" type="text/css">
   </head>
   <body>
     <h1>Reference</h1>

--- a/en/operators/core/addresspart.html
+++ b/en/operators/core/addresspart.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Core:Address Part Operator</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css" />
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
   </head>
   <body>
     <h1>Address Part</h1>

--- a/en/operators/core/comparator.html
+++ b/en/operators/core/comparator.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Core:Comparisons</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <link href="./../../../style.css" rel="Stylesheet" type="text/css" />
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style.css" rel="Stylesheet" type="text/css">
   </head>
   <body>
     <h1>Comparisons Across Character Sets</h1>

--- a/en/operators/core/matchtype.html
+++ b/en/operators/core/matchtype.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Core:Match type Operator</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css" />
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
   </head>
   <body>
     <h1>Match type</h1>

--- a/en/test/core/address.html
+++ b/en/test/core/address.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Core:Address Test</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css" />
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
   </head>
   <body>
     <h1>Address</h1>

--- a/en/test/core/allof.html
+++ b/en/test/core/allof.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Core:Allof Test</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css" />
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
   </head>
   <body>
     <h1>Allof</h1>
@@ -22,12 +21,12 @@
     <h2>Example</h2>
     <div>
       <code>
-        if anyof (exists ["From", "Date"],<br/>
-             header :contains "from" "fool@example.edu", <br/>
-             header :matches "Subject" ["*money*","*Viagra*"])<br/> 
-             {<br/>
-                discard;<br/>
-             }<br/>
+        if anyof (exists ["From", "Date"],<br>
+             header :contains "from" "fool@example.edu", <br>
+             header :matches "Subject" ["*money*","*Viagra*"])<br> 
+             {<br>
+                discard;<br>
+             }<br>
       </code>
     </div>
         

--- a/en/test/core/anyof.html
+++ b/en/test/core/anyof.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Core:Anyof Test</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css" />
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
   </head>
   <body>
     <h1>Anyof</h1>

--- a/en/test/core/envelope.html
+++ b/en/test/core/envelope.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Core:Envelope Test</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css" />
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
   </head>
   <body>
     <h1>Envelope</h1>
@@ -58,10 +57,10 @@
     <h2>Example</h2>
     <div>
       <code>
-        require "envelope";<br/>
-        if envelope :all :is "from" "tim@example.com" {<br/>
-        &nbsp;&nbsp;discard;<br/>
-        }<br/>
+        require "envelope";<br>
+        if envelope :all :is "from" "tim@example.com" {<br>
+        &nbsp;&nbsp;discard;<br>
+        }<br>
       </code>
     </div>
         

--- a/en/test/core/exists.html
+++ b/en/test/core/exists.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Core:Exists Test</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css" />
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
   </head>
   <body>
     <h1>Exists</h1>
@@ -28,9 +27,9 @@
     </p>
     <div>
       <code>
-        if not exists ["From","Date"] {<br/>
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;discard;<br/>
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+        if not exists ["From","Date"] {<br>
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;discard;<br>
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br>
       </code>
     </div>
         

--- a/en/test/core/false.html
+++ b/en/test/core/false.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Core:False Test</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css" />
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
   </head>
   <body>
     <h1>False</h1>

--- a/en/test/core/header.html
+++ b/en/test/core/header.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Core:Header Test</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css" />
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
   </head>
   <body>
     <h1>Header</h1>
@@ -41,8 +40,8 @@
     </p>
     <blockquote>
       <p>
-        header :is ["X-Caffeine"] [""]  --  evaluates to false<br/>
-        header :contains ["X-Caffeine"] [""]  -- evaluates to true<br/>
+        header :is ["X-Caffeine"] [""]  --  evaluates to false<br>
+        header :contains ["X-Caffeine"] [""]  -- evaluates to true<br>
       </p>
     </blockquote>
         

--- a/en/test/core/not.html
+++ b/en/test/core/not.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Core:Not Test</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css" />
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
   </head>
   <body>
     <h1>Not</h1>

--- a/en/test/core/size.html
+++ b/en/test/core/size.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Core:Size Test</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css" />
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
   </head>
   <body>
     <h1>Size</h1>

--- a/en/test/core/true.html
+++ b/en/test/core/true.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Core:True Test</title>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css" />
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
   </head>
   <body>
     <h1>True</h1>


### PR DESCRIPTION
<sup>Originally for [ProtonMail/sieve-reference](https://github.com/ProtonMail/sieve-reference/pull/1), but should fit here, too.</sup>
I've just updated the .html -files so they are now HTML5 :smiley: