### PR TITLE
Added documentation for RFC5173 Body Extension.

### DIFF
--- a/en/content.html
+++ b/en/content.html
@@ -19,10 +19,16 @@
       <li><a href="./test/core/allof.html">allof</a></li>
       <li><a href="./test/core/anyof.html">anyof</a></li>
     </ul>
+
+    <h2>B</h2>
+    <ul>
+      <li><a href="./test/ext/body.html">body</a></li>
+    </ul>
     
     <h2>C</h2>
     <ul>
       <li><a href="./operators/core/matchtype.html">:contains</a></li>
+      <li><a href="./operators/ext/bodytransform.html">:content</a></li>
     </ul>
     
     <h2>D</h2>
@@ -78,11 +84,13 @@
   <a href="./control/core/require.html">require</a>         
   <a href="./action/core/reject.html">reject</a>
   <a href="./action/core/redirect.html">redirect</a>
+  <a href="./operators/ext/bodytransform.html">raw</a>
   
   <a href="./control/core/stop.html">stop</a>  
   <a href="./test/core/size.html">size</a>
   
   <a href="./test/core/true.html">true</a>
+  <a href="./operators/ext/bodytransform.html">text</a>
     
 
   testlist

--- a/en/extensions/ietf/body.html
+++ b/en/extensions/ietf/body.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Sieve Body Extension</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
+  </head>
+  <body>
+    <h1>Body Extension</h1>
+
+    <h2>Test Commands</h2>
+    <p>
+      <a href="./../../test/ext/body.html">body</a>
+    </p>
+
+    <h2>Operators</h2>
+    <p>
+      <a href="./../../operators/ext/bodytransform.html">body transform</a>
+    </p>
+
+    <h2>Resources</h2>
+    <p>
+      RFC5173
+    </p>
+  </body>
+</html>  

--- a/en/index.html
+++ b/en/index.html
@@ -53,6 +53,10 @@
       <a href="./atoms/core/string.html">string</a>  
       <a href="./atoms/core/stringlist.html">stringlist</a>
     </p>
-    
+
+    <h2>Extensions</h2>
+    <p>
+      <a href="./extensions/ietf/body.html">body</a>
+    </p>
   </body>
 </html>  

--- a/en/operators/ext/bodytransform.html
+++ b/en/operators/ext/bodytransform.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Body:Body Transform Operator</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
+  </head>
+  <body>
+    <h1>Body Transform</h1>
+
+    <h2>Syntax</h2>
+    <p>
+      ":raw" / ":content" <em>&lt;content-types: <a href="./../../atoms/core/stringlist.html">string-list</a>&gt;</em> / ":text"
+    </p>
+
+    <h2>Description</h2>
+    <p>
+      Prior to matching content in a message body, "transformations" can be
+      applied that filter and decode certain parts of the body.  These
+      transformations are selected by a "BODY-TRANSFORM" keyword parameter.
+    </p>
+    <p>
+      The default transformation is :text.
+    </p>
+    <p>
+      The ":raw" transform matches against the entire undecoded body of a
+      message as a single item.
+    </p>
+    <p>
+      If the specified body-transform is ":raw", the [MIME] structure of
+      the body is irrelevant.  The implementation MUST NOT remove any
+      transfer encoding from the message, MUST NOT refuse to filter
+      messages with syntactic errors (unless the environment it is part of
+      rejects them outright), and MUST treat multipart boundaries or the
+      MIME headers of enclosed body parts as part of the content being
+      matched against, instead of MIME structures to interpret.
+    </p>
+    <p>
+      If the body transform is ":content", the MIME parts that have the
+      specified content types are matched against independently.
+    </p>
+    <p>
+      If an individual content type begins or ends with a '/' (slash) or
+      contains multiple slashes, then it matches no content types.
+      Otherwise, if it contains a slash, then it specifies a full
+      &lt;type>/&lt;subtype> pair, and matches only that specific content type.
+      If it is the empty string, all MIME content types are matched.
+      Otherwise, it specifies a &lt;type> only, and any subtype of that type
+      matches it.
+    </p>
+    <p>
+      The search for MIME parts matching the :content specification is
+      recursive and automatically descends into multipart and
+      message/rfc822 MIME parts.  All MIME parts with matching types are
+      searched for the key strings.  The test returns true if any
+      combination of a searched MIME part and key-list argument match.
+    </p>
+    <p>
+      If the :content specification matches a multipart MIME part, only the
+      prologue and epilogue sections of the part will be searched for the
+      key strings, treating the entire prologue and the entire epilogue as
+      separate strings; the contents of nested parts are only searched if
+      their respective types match the :content specification.
+    </p>
+    <p>
+      If the :content specification matches a message/rfc822 MIME part,
+      only the header of the nested message will be searched for the key
+      strings, treating the header as a single string; the contents of the
+      nested message body parts are only searched if their content type
+      matches the :content specification.
+    </p>
+    <p>
+      For other MIME types, the entire part will be searched as a single
+      string.
+    </p>
+    <p>
+      (Matches against container types with an empty match string can be
+      useful as tests for the existence of such parts.)
+    </p>
+    <p>
+      The ":text" body transform matches against the results of an
+      implementation's best effort at extracting UTF-8 encoded text from a
+      message.
+    </p>
+    <p>
+      It is unspecified whether this transformation results in a single
+      string or multiple strings being matched against.  All the text
+      extracted from a given non-container MIME part MUST be in the same
+      string.
+    </p>
+    <p>
+      In simple implementations, :text MAY be treated the same as :content
+      "text".
+    </p>
+    <p>
+      Sophisticated implementations MAY strip mark-up from the text prior
+      to matching, and MAY convert media types other than text to text
+      prior to matching.
+    </p>
+    <p>
+      (For example, they may be able to convert proprietary text editor
+      formats to text or apply optical character recognition algorithms to
+      image data.)
+    </p>
+
+    <h2>Module</h2>
+    <p>
+      Body : Requires import of the <code>"body"</code> capability
+    </p>
+
+    <h2>Resources</h2>
+    <p>
+      RFC5173
+    </p>
+  </body>
+</html>

--- a/en/test/ext/body.html
+++ b/en/test/ext/body.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Ext:Body Test</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
+  </head>
+  <body>
+    <h1>Body</h1>
+
+    <h2>Syntax</h2>
+    <p>
+      body
+      <em>[<a href="./../../operators/core/comparator.html">COMPARATOR</a>]</em>
+      <em>[<a href="./../../operators/core/matchtype.html">MATCH-TYPE</a>]</em>
+      <em>[<a href="./../../operators/ext/bodytransform.html">BODY-TRANSFORM</a>]</em>
+      <em>&lt;key-list: <a href="./../../atoms/core/stringlist.html">string-list</a>&gt;</em>
+    </p>
+
+    <h2>Description</h2>
+    <p>
+      The body test matches content in the body of an email message, that
+      is, anything following the first empty line after the header.  (The
+      empty line itself, if present, is not considered to be part of the
+      body.)
+    </p>
+    <p>
+      The COMPARATOR and MATCH-TYPE keyword parameters are defined in
+      [SIEVE].  As specified in Sections 2.7.1 and 2.7.3 of [SIEVE], the
+      default COMPARATOR is "i;ascii-casemap" and the default MATCH-TYPE is
+      ":is".
+    </p>
+    <p>
+      The BODY-TRANSFORM is a keyword parameter that governs how a set of
+      strings to be matched against are extracted from the body of the
+      message.  If a message consists of a header only, not followed by an
+      empty line, then that set is empty and all "body" tests return false,
+      including those that test for an empty string.  (This is similar to
+      how the "<a href="./../core/header.html">header</a>" test always fails when the named header fields
+      aren't present.)  Otherwise, the transform must be followed as
+      defined <a href="./../../operators/ext/bodytransform.html">on this page</a>.
+    </p>
+    <p>
+      Note that the transformations defined here do <em>not</em> match against
+      each line of the message independently, so the strings will usually
+      contain CRLFs.  How these can be matched is governed by the
+      comparator and match-type.  For example, with the default comparator
+      of "i;ascii-casemap", they can be included literally in the key
+      strings, or be matched with the "*" or "?" wildcards of the :matches
+      match-type, or be skipped with :contains.
+    </p>
+
+    <h2>Example</h2>
+    <div>
+      <code>
+        if body :raw :contains "MAKE MONEY FAST" {
+        &nbsp;&nbsp;discard;
+        }
+      </code>
+    </div>
+
+    <h2>Module</h2>
+    <p>
+      Body : Requires import of the <code>"body"</code> capability
+    </p>
+
+    <h2>Resources</h2>
+    <p>
+      RFC5173
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
Basic idea:

- command docs go in `/ext/` rathere than `/core/`
- each extension has an overview page that acts like `index.html` for the core
- extension overview pages are split in `/ietf/` and `/vnd/` for vendor-specific extensions.