### PR TITLE
Added documentation for RFC6558 Convert Extension.

### DIFF
--- a/en/action/ext/convert.html
+++ b/en/action/ext/convert.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Convert:Convert Action</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
+  </head>
+  <body>
+    <h1>Convert</h1>
+
+    <h2>Syntax</h2>
+    <p>
+      convert
+      <em>&lt;quoted-from-media-type : <a href="./../../atoms/core/string.html">string</a>&gt;</em>
+      <em>&lt;quoted-to-media-type : <a href="./../../atoms/core/string.html">string</a>&gt;</em>
+      <em>&lt;transcoding-params : <a href="./../../atoms/core/stringlist.html">string-list</a>&gt;</em>
+      ;
+    </p>
+
+    <h2>Description</h2>
+    <p>
+      The "convert" action specifies that all body parts with a media type
+      [RFC2046] (sometimes called "MIME type") equal to
+      <em>&lt;quoted-from-media-type></em> be converted to the media type in
+      <em>&lt;quoted-to-media-type></em> using conversion parameters specified in
+      <em>&lt;transcoding-params></em>.  Each conversion parameter value has the
+      following syntax: "<em>&lt;transcoding-param-name></em>=<em>&lt;transcoding-param-value></em>",
+      where <em>&lt;transcoding-param-name></em> and <em>&lt;transcoding-param-value></em>
+      are defined in CONVERT [RFC5259]. Messages that don't have any body
+      parts with the <em>&lt;quoted-from-media-type></em> media type are not affected
+      by the conversion.
+    </p>
+    <p>
+      The "convert" action can be used with Sieve MIME Part Tests
+      [RFC5703], in the case that some, but not all of the body parts need
+      to be converted, or where different body parts might require
+      different conversions.  When the "convert" action appears in a
+      "foreverypart" loop, it applies only to the body part being
+      processed, and not to any other body parts.
+    </p>
+    <p>
+      When the "convert" action appears outside a "foreverypart" loop, the
+      conversion applies equally to all body parts -- that is, all body
+      parts that have the "quoted-from-media-type" are converted, using the
+      same transcoding parameters.
+    </p>
+    <p>
+      A single "convert" action will only apply once to any body part.  If,
+      for example,
+      <code>convert "image/jpeg" "image/jpeg" ["pix-x=100","pix-y=120"]</code>
+      converts a larger JPEG image to the smaller 100 x 120
+      size, that will be the end of that "convert" action on that body
+      part.  The action will not see a "new" JPEG body part to process,
+      resulting from the conversion.
+    </p>
+    <p>
+      If a "convert" action cannot be completed -- perhaps because the
+      conversion failed, or because the requested conversion is not
+      available -- that "convert" action MUST terminate and leave the
+      message unchanged, rolling back any other conversions done by that
+      action.  The script processing continues, and prior or subsequent
+      "convert" actions are not affected.  No error condition is raised,
+      and no partial conversions from a single "convert" action are
+      allowed.
+    </p>
+
+    <h2>Example</h2>
+    <p>
+      In the following example, all "image/tiff" body parts of the message
+      are converted to "image/jpeg" with image resolution of 320x240
+      pixels.  The converted message is then subject to the implicit keep.
+    </p>
+    <div>
+      <code>
+         require ["convert"];
+         convert "image/tiff" "image/jpeg" ["pix-x=320","pix-y=240"];
+      </code>
+    </div>
+
+    <h2>Module</h2>
+    <p>
+      Convert : Requires import of the <code>"convert"</code> capability
+    </p>
+
+    <h2>Resources</h2>
+    <p>
+      RFC6558<br>
+      RFC5259
+    </p>
+  </body>
+</html>

--- a/en/content.html
+++ b/en/content.html
@@ -30,6 +30,7 @@
     <ul>
       <li><a href="./operators/core/matchtype.html">:contains</a></li>
       <li><a href="./operators/ext/bodytransform.html">:content</a></li>
+      <li>convert (<a href="./action/ext/convert.html">action</a>|<a href="./test/ext/convert.html">test</a>)</li>
     </ul>
     
     <h2>D</h2>

--- a/en/extensions/ietf/convert.html
+++ b/en/extensions/ietf/convert.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Sieve Convert Extension</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
+  </head>
+  <body>
+    <h1>Convert Extension</h1>
+
+    <h2>Action Commands</h2>
+    <p>
+      <a href="./../../action/ext/convert.html">convert</a>
+    </p>
+
+    <h2>Test Commands</h2>
+    <p>
+      <a href="./../../test/ext/convert.html">convert</a>
+    </p>
+
+    <h2>Resources</h2>
+    <p>
+      RFC6558<br>
+      RFC5259
+    </p>
+  </body>
+</html>  

--- a/en/index.html
+++ b/en/index.html
@@ -57,6 +57,7 @@
     <h2>Extensions</h2>
     <p>
       <a href="./extensions/ietf/body.html">body</a>
+      <a href="./extensions/ietf/convert.html">convert</a>
     </p>
   </body>
 </html>  

--- a/en/test/ext/convert.html
+++ b/en/test/ext/convert.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Convert:Convert Test</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./../../../style/style.css" rel="Stylesheet" type="text/css">
+  </head>
+  <body>
+    <h1>Convert</h1>
+
+    <h2>Syntax</h2>
+    <p>
+      convert
+      <em>&lt;quoted-from-media-type : <a href="./../../atoms/core/string.html">string</a>&gt;</em>
+      <em>&lt;quoted-to-media-type : <a href="./../../atoms/core/string.html">string</a>&gt;</em>
+      <em>&lt;transcoding-params : <a href="./../../atoms/core/stringlist.html">string-list</a>&gt;</em>
+      ;
+    </p>
+
+    <h2>Description</h2>
+    <p>
+      To simplify testing for supported and successful conversions, the
+      "<a href="./../../action/ext/convert.html">convert</a>" action can also be used as a test.  As such, it will
+      attempt to perform the requested conversion(s) and will evaluate to
+      "false" if and only if at least one conversion failed.  The failure
+      can be because a conversion was unsupported or because the data could
+      not be converted (perhaps it had been corrupted in transit or
+      mislabeled at its origin).
+    </p>
+    <p>
+      This creates a new type of Sieve action, a "testable action".  The
+      usage as a test is exactly the same as for an action, and it doubles
+      as an action and a test of the action's result at the same time.  See
+      below for an example of how this test can be used.
+    </p>
+
+    <h2>Example</h2>
+    <p>
+      In the following example, all "image/tiff" body parts of the message
+      are converted to "image/jpeg".  If the conversions
+      were successful, those messages are then filed into a mailbox called
+      "INBOX.pics".
+    </p>
+    <div>
+      <code>
+        require ["fileinto", "convert"];
+        if (convert "image/tiff" "image/jpeg" ["pix-x=320","pix-y=240"])
+        {
+        &nbsp;&nbsp;fileinto "INBOX.pics";
+        }
+      </code>
+    </div>
+
+    <h2>Module</h2>
+    <p>
+      Convert : Requires import of the <code>"convert"</code> capability
+    </p>
+
+    <h2>Resources</h2>
+    <p>
+      RFC6558<br>
+      RFC5259
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
Following the same structure as body extension.

The weird thing is that `convert` is an action that doubles as a test, something not intended by the original Sieve spec.

For now I split documentation up to fit the current separation, with general documentation in the `action` page and test specifics in the `test` page.